### PR TITLE
Create VGN-P11Z.conf

### DIFF
--- a/config/xorg.conf/VGN-P11Z.conf
+++ b/config/xorg.conf/VGN-P11Z.conf
@@ -1,0 +1,62 @@
+#Section "ServerLayout"
+#    Identifier      "VGN-P11Z Layout"
+#    Screen 0        "Screen0"      0 0
+#EndSection
+
+Section "Device"
+    Identifier "IntelEMGD"
+    Driver     "emgd"
+    VendorName "Intel(R)"
+    BoardName  "Embedded Graphics"
+    BusID      "0:2:0"
+    Screen     0
+    VideoRam   32768
+
+    #Option "AccelMethod" "EXA"
+    #Option "DRI" "on"
+    #Option "MigrationHeuristic" "greedy"
+    #Option "IgnoreACPI" "yes"
+
+    Option     "PcfVersion"                          "1792"
+    Option     "ConfigId"                            "1"
+    Option     "ALL/1/name"                          "iegd"
+    Option     "ALL/1/General/PortOrder"             "42000"
+    Option     "ALL/1/General/DisplayConfig"         "1"
+    Option     "ALL/1/General/DisplayDetect"         "0"
+    Option     "ALL/1/General/FbBlendOvl"            "1"
+    Option     "ALL/1/Port/4/name"                   "Port 4"
+    Option     "ALL/1/Port/4/General/EdidAvail"      "0"
+    Option     "ALL/1/Port/4/General/EdidNotAvail"   "5"
+    Option     "ALL/1/Port/4/General/Rotation"       "0"
+    Option     "ALL/1/Port/4/General/Edid"           "0"
+    Option     "ALL/1/Port/4/Dtd/1/PixelClock"       "72300"
+    #Option     "ALL/1/Port/4/Dtd/1/HorzActive"       "1366"
+    Option     "ALL/1/Port/4/Dtd/1/HorzActive"       "1600"
+    Option     "ALL/1/Port/4/Dtd/1/HorzSync"         "48"
+    Option     "ALL/1/Port/4/Dtd/1/HorzSyncPulse"    "32"
+    Option     "ALL/1/Port/4/Dtd/1/HorzBlank"        "160"
+    #Option     "ALL/1/Port/4/Dtd/1/VertActive"       "768"
+    Option     "ALL/1/Port/4/Dtd/1/VertActive"       "768"
+    Option     "ALL/1/Port/4/Dtd/1/VertSync"         "3"
+    Option     "ALL/1/Port/4/Dtd/1/VertSyncPulse"    "5"
+    Option     "ALL/1/Port/4/Dtd/1/VertBlank"        "22"
+    Option     "ALL/1/Port/4/Dtd/1/Flags"            "0x20000"
+    Option     "ALL/1/Port/4/Attr/27"                "0"
+    Option     "ALL/1/Port/4/Attr/26"                "18"
+    Option     "ALL/1/Port/4/Attr/60"                "1"
+    Option     "ALL/1/Port/4/Attr/70"                "100"
+    Option     "ALL/1/Port/4/Attr/71"                "20300"
+    Option     "PortDrivers"                         "sdvo lvds"
+EndSection
+
+#Section "Screen"
+#        Identifier    "Screen0"
+#        Device        "IntelEMGD"
+#        SubSection "Display"
+#                Modes   "1680x1050" "1366x768" "1280x1024"  "1024x768"   "640x480"
+#        EndSubSection
+#EndSection
+
+#Section "DRI"
+#    Mode         0666
+#EndSection


### PR DESCRIPTION
EMGD driver configuration for the Sony Vaio VGN-P11Z

only resolution 1600x768 being offered
suspend and brightness keys not working yet
