### PR TITLE
Fixed linux-headers dependency for Debian Stretch

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Thomas-Karl Pietrowski <thopiekar@googlemail.com>
 Build-Depends: debhelper (>= 9),
  rpm2cpio, cpio,
- dkms, linux-headers-generic [i386 amd64], libtool,
+ dkms, linux-headers-generic [i386 amd64] | linux-headers-686 | linux-headers-686-pae | linux-headers-amd64, libtool,
 # emgdgui - shlibs
  libxrandr2, libglade2-0, libxext6, libx11-6, libgtk2.0-0, libgdk-pixbuf2.0-0,
 # dri driver

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Thomas-Karl Pietrowski <thopiekar@googlemail.com>
 Build-Depends: debhelper (>= 9),
  rpm2cpio, cpio,
- dkms, linux-headers-generic [i386 amd64] | linux-headers-686 | linux-headers-686-pae | linux-headers-amd64, libtool,
+ dkms, linux-headers-generic [i386] | linux-headers-686 | linux-headers-686-pae, libtool,
 # emgdgui - shlibs
  libxrandr2, libglade2-0, libxext6, libx11-6, libgtk2.0-0, libgdk-pixbuf2.0-0,
 # dri driver


### PR DESCRIPTION
Debian [renamed the packages](http://google.com/search?q=site:packages.debian.org+linux-headers+inurl:stretch) at some point between when `debian/control` was written and now.

This patch fixes those dependencies' syntax.